### PR TITLE
remove unsupported darwin/amd64

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -11,7 +11,7 @@
   ],
   "build": {
     "build": "make module.tar.gz",
-    "arch" : ["linux/amd64", "linux/arm64", "darwin/amd64", "darwin/arm64"]
+    "arch" : ["linux/amd64", "linux/arm64", "darwin/arm64"]
   },
   "entrypoint": "object-tracker"
 }


### PR DESCRIPTION
## What changed
- remove darwin/amd64 from the meta.json arch list
## Why
We removed darwin/amd64 support from our build service