### PR TITLE
RSDK-9371 - Reset obj-tracker counter at given time

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ The following attributes are available for `viam:vision:object-tracker` vision s
 | `max_frequency_hz`    | float64            | **Optional** | The fastest frequency (in Hz) that the model should run in. Default = 10.                                                                                                                  |
 | `chosen_labels`       | map[string]float64 | **Optional** | A list of class names (string) and confidence scores (float[0-1]) such that **only** detections with a class name in the list and a confidence above the corresponding score are included. |
 | `trigger_cool_down_s` | float64            | **Optional** | The duration (in seconds) before the trigger goes back to `empty`. Default = 5.                                                                                                            |
-| `buffer_size`         | int                | **Optional** | SIze of the buffer that stores lost bounding boxes. Default = 30. Min = 1. Max = 256.                                                                                                      |
+| `buffer_size`         | int                | **Optional** | Size of the buffer that stores lost bounding boxes. Default = 30. Min = 1. Max = 256.                                                                                                      |
+| `reset_time`          | string             | **Optional** | The time, written "HH:MM:SS", at which to restart the tracker's class counter. Default = "00:00:00" (midnight)                                                                             |
 ### Usage
 
 This module is made for use with the following methods of the [vision service API](https://docs.viam.com/services/vision/#api): 

--- a/object_tracker/labels.go
+++ b/object_tracker/labels.go
@@ -5,7 +5,6 @@
 package object_tracker
 
 import (
-	"fmt"
 	objdet "go.viam.com/rdk/vision/objectdetection"
 	"strconv"
 	"strings"
@@ -15,7 +14,7 @@ import (
 // GetTimestamp will retrieve and format a timestamp to be YYYYMMDD_HHMMSS
 func GetTimestamp() string {
 	currTime := time.Now()
-	return fmt.Sprintf(currTime.Format("20060102_150405"))
+	return string(currTime.Format("20060102_150405"))
 }
 
 // ReplaceLabel replaces the detection with an almost identical detection (new label)

--- a/object_tracker/object_tracker.go
+++ b/object_tracker/object_tracker.go
@@ -4,26 +4,24 @@ package object_tracker
 import (
 	"context"
 	"fmt"
+	"image"
 	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
-	"go.viam.com/rdk/gostream"
-	"go.viam.com/rdk/vision/viscapture"
-
-	"image"
-
 	hg "github.com/charles-haynes/munkres"
 	"github.com/pkg/errors"
 	"go.viam.com/rdk/components/camera"
+	"go.viam.com/rdk/gostream"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/services/vision"
 	vis "go.viam.com/rdk/vision"
 	"go.viam.com/rdk/vision/classification"
 	objdet "go.viam.com/rdk/vision/objectdetection"
+	"go.viam.com/rdk/vision/viscapture"
 	viamutils "go.viam.com/utils"
 )
 

--- a/object_tracker/object_tracker_test.go
+++ b/object_tracker/object_tracker_test.go
@@ -1,12 +1,13 @@
 package object_tracker
 
 import (
+	"image"
+	"testing"
+
 	hg "github.com/charles-haynes/munkres"
 	"go.viam.com/rdk/services/vision"
 	objdet "go.viam.com/rdk/vision/objectdetection"
 	"go.viam.com/test"
-	"image"
-	"testing"
 )
 
 const (
@@ -102,9 +103,7 @@ func TestTracker(t *testing.T) {
 	// Store oldDetection and lost detections in allDetections
 	allDetections := fakeTracker.lastDetections
 	for _, dets := range fakeTracker.lostDetectionsBuffer.detections {
-		for _, det := range dets {
-			allDetections = append(allDetections, det)
-		}
+		allDetections = append(allDetections, dets...)
 	}
 
 	// Build and solve cost matrix via Munkres' method
@@ -147,9 +146,7 @@ func TestTracker(t *testing.T) {
 	// Store oldDetection and lost detections in allDetections
 	allDetections = fakeTracker.lastDetections
 	for _, dets := range fakeTracker.lostDetectionsBuffer.detections {
-		for _, det := range dets {
-			allDetections = append(allDetections, det)
-		}
+		allDetections = append(allDetections, dets...)
 	}
 
 	// Build and solve cost matrix via Munkres' method


### PR DESCRIPTION
This feature was requested mainly for customer reporting. Made it so the time was configurable. Successfully tested on Mac. This module still could use some standardization but that's another problem for another PR.