### PR TITLE
Add persistence requirement before labeling new object

### DIFF
--- a/object_tracker/labels.go
+++ b/object_tracker/labels.go
@@ -6,10 +6,12 @@ package object_tracker
 
 import (
 	"fmt"
-	objdet "go.viam.com/rdk/vision/objectdetection"
+	"image"
 	"strconv"
 	"strings"
 	"time"
+
+	objdet "go.viam.com/rdk/vision/objectdetection"
 )
 
 // GetTimestamp will retrieve and format a timestamp to be YYYYMMDD_HHMMSS
@@ -19,46 +21,65 @@ func GetTimestamp() string {
 }
 
 // ReplaceLabel replaces the detection with an almost identical detection (new label)
-func ReplaceLabel(det objdet.Detection, label string) objdet.Detection {
-	return objdet.NewDetection(*det.BoundingBox(), det.Score(), label)
+func ReplaceLabel(tr *track, label string) *track {
+	det := objdet.NewDetection(*tr.Det.BoundingBox(), tr.Det.Score(), label)
+	newTrack := tr.clone()
+	newTrack.Det = det
+	return newTrack
+}
+
+// ReplaceBoundingBox replaces the detection with an almost identical detection (new bounding box)
+func ReplaceBoundingBox(tr *track, bb *image.Rectangle) *track {
+	det := objdet.NewDetection(*bb, tr.Det.Score(), tr.Det.Label())
+	newTrack := tr.clone()
+	newTrack.Det = det
+	return newTrack
 }
 
 // RenameFromMatches takes the output of the Hungarian matching algorithm and
 // gives the new detection the same label as the matching old detection.  Any new detections
 // found will be given a new name (and cleass counter will be updated)
 // Also return freshDets that are the fresh detections that were not matched with any detections in the previous frame.
-func (t *myTracker) RenameFromMatches(matches []int, matchinMtx [][]float64, oldDets, newDets []objdet.Detection) ([]objdet.Detection, []objdet.Detection) {
+func (t *myTracker) RenameFromMatches(matches []int, matchinMtx [][]float64, oldDets, newDets []*track) ([]*track, []*track, []*track) {
 	// Fill up a map with the indices of newDetections we have
 	notUsed := make(map[int]struct{})
 	for i, _ := range newDets {
 		notUsed[i] = struct{}{}
 	}
 	// Go through valid matches and update name and track
+	updatedTracks := make([]*track, 0)
+	newlyStableTracks := make([]*track, 0)
 	for oldIdx, newIdx := range matches {
 		if newIdx != -1 {
 			if matchinMtx[oldIdx][newIdx] != 0 {
 				if newIdx >= 0 && newIdx < len(newDets) && oldIdx >= 0 && oldIdx < len(oldDets) {
-					newDets[newIdx] = ReplaceLabel(newDets[newIdx], oldDets[oldIdx].Label())
-					t.UpdateTrack(newDets[newIdx])
+					// take the old track, clone it, and update their Bounding Box
+					// to the new track. Increment its persistence counter.
+					updatedTrack, newlyStable := t.UpdateTrack(newDets[newIdx], oldDets[oldIdx])
+					if newlyStable {
+						newlyStableTracks = append(newlyStableTracks, updatedTrack)
+					} else {
+						updatedTracks = append(updatedTracks, updatedTrack)
+					}
 					delete(notUsed, newIdx)
 				}
 			}
 		}
 	}
 	// Go through all NEW things and add them in (name them and start new track)
-	var freshDets []objdet.Detection
+	freshTracks := make([]*track, 0)
 	for idx := range notUsed {
 		newDet := t.RenameFirstTime(newDets[idx])
 		newDets[idx] = newDet
-		freshDets = append(freshDets, newDet)
+		freshTracks = append(freshTracks, newDet)
 	}
-	return newDets, freshDets
+	return updatedTracks, newlyStableTracks, freshTracks
 }
 
 // RenameFirstTime should activate whenever a new object appears.
 // It will start or update a class counter for whichever class and create a new track.
-func (t *myTracker) RenameFirstTime(det objdet.Detection) objdet.Detection {
-	baseLabel := strings.ToLower(strings.Split(det.Label(), "_")[0])
+func (t *myTracker) RenameFirstTime(det *track) *track {
+	baseLabel := strings.ToLower(strings.Split(det.Det.Label(), "_")[0])
 	classCount, ok := t.classCounter[baseLabel]
 	if !ok {
 		t.classCounter[baseLabel] = 0
@@ -67,15 +88,29 @@ func (t *myTracker) RenameFirstTime(det objdet.Detection) objdet.Detection {
 	}
 	countLabel := baseLabel + "_" + strconv.Itoa(t.classCounter[baseLabel])
 	label := countLabel + "_" + GetTimestamp()
-	out := objdet.NewDetection(*det.BoundingBox(), det.Score(), label)
-	t.tracks[countLabel] = []objdet.Detection{out} // Start new track with this one
+	out := ReplaceLabel(det, label)
+	// start a new track, but it will be tentative, and may be removed if lost
+	// before persistence counter reaches "stable"
+	t.tracks[countLabel] = []*track{out}
 	return out
 }
 
-func (t *myTracker) UpdateTrack(det objdet.Detection) {
-	countLabel := strings.Join(strings.Split(det.Label(), "_")[0:2], "_")
-	track, ok := t.tracks[countLabel]
+func getTrackingLabel(tr *track) string {
+	return strings.Join(strings.Split(tr.Det.Label(), "_")[0:2], "_")
+}
+
+// UpdateTrack changes the old bounding box to the new one, updates persistence,
+// and also returns if the track became newly stable
+func (t *myTracker) UpdateTrack(nextTrack, oldMatchedTrack *track) (*track, bool) {
+	wasStable := oldMatchedTrack.isStable()
+	newTrack := ReplaceBoundingBox(oldMatchedTrack, nextTrack.Det.BoundingBox())
+	newTrack.addPersistence()
+	countLabel := getTrackingLabel(newTrack)
+	trackSlice, ok := t.tracks[countLabel]
 	if ok {
-		t.tracks[countLabel] = append(track, det)
+		t.tracks[countLabel] = append(trackSlice, newTrack)
 	}
+	isNowStable := newTrack.isStable()
+	newlyStable := wasStable != isNowStable
+	return newTrack, newlyStable
 }

--- a/object_tracker/object_tracker.go
+++ b/object_tracker/object_tracker.go
@@ -4,13 +4,15 @@ package object_tracker
 import (
 	"context"
 	"fmt"
-	"go.viam.com/rdk/gostream"
-	"go.viam.com/rdk/vision/viscapture"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"go.viam.com/rdk/gostream"
+	"go.viam.com/rdk/vision/viscapture"
+
+	"image"
 
 	hg "github.com/charles-haynes/munkres"
 	"github.com/pkg/errors"
@@ -22,7 +24,6 @@ import (
 	"go.viam.com/rdk/vision/classification"
 	objdet "go.viam.com/rdk/vision/objectdetection"
 	viamutils "go.viam.com/utils"
-	"image"
 )
 
 // ModelName is the name of the model
@@ -32,13 +33,14 @@ const (
 )
 
 var (
-	// Here is where we define your new model's colon-delimited-triplet (viam:vision:object-tracker)
-	Model                  = resource.NewModel("viam", "vision", ModelName)
-	errUnimplemented       = errors.New("unimplemented")
-	DefaultMinConfidence   = 0.2
-	DefaultMaxFrequency    = 10.0
-	DefaultTriggerCoolDown = 5.0
-	DefaultBufferSize      = 30
+	// Here is where we define your new model's colon-delimited-triplet
+	Model                      = resource.NewModel("viam", "vision", ModelName)
+	errUnimplemented           = errors.New("unimplemented")
+	DefaultMinTrackPersistence = 3
+	DefaultMinConfidence       = 0.2
+	DefaultMaxFrequency        = 10.0
+	DefaultTriggerCoolDown     = 5.0
+	DefaultBufferSize          = 30
 )
 
 type allObjects struct {
@@ -48,7 +50,7 @@ type allObjects struct {
 
 type currentDetections struct {
 	mutex      sync.RWMutex
-	detections []objdet.Detection
+	detections []*track
 }
 
 func init() {
@@ -67,10 +69,10 @@ type myTracker struct {
 	triggerContext    context.Context
 
 	activeBackgroundWorkers sync.WaitGroup
-	lastDetections          []objdet.Detection
+	lastDetections          []*track
 	currDetections          currentDetections
 	currImg                 atomic.Pointer[image.Image]
-	lostDetectionsBuffer    *detectionsBuffer
+	lostDetectionsBuffer    *tracksBuffer
 
 	allFreshObjects allObjects
 
@@ -78,15 +80,16 @@ type myTracker struct {
 	coolDown    float64
 	properties  vision.Properties
 
-	cam           camera.Camera
-	camName       string
-	detector      vision.Service
-	frequency     float64
-	minConfidence float64
-	chosenLabels  map[string]float64
-	classCounter  map[string]int
-	tracks        map[string][]objdet.Detection
-	timeStats     []time.Duration
+	cam                 camera.Camera
+	camName             string
+	detector            vision.Service
+	frequency           float64
+	minConfidence       float64
+	chosenLabels        map[string]float64
+	classCounter        map[string]int
+	tracks              map[string][]*track
+	timeStats           []time.Duration
+	minTrackPersistence int
 }
 
 func newTracker(ctx context.Context, deps resource.Dependencies, conf resource.Config, logger logging.Logger) (vision.Service, error) {
@@ -94,7 +97,7 @@ func newTracker(ctx context.Context, deps resource.Dependencies, conf resource.C
 		Named:        conf.ResourceName().AsNamed(),
 		logger:       logger,
 		classCounter: make(map[string]int),
-		tracks:       make(map[string][]objdet.Detection),
+		tracks:       make(map[string][]*track),
 		properties: vision.Properties{
 			ClassificationSupported: true,
 			DetectionSupported:      true,
@@ -110,6 +113,10 @@ func newTracker(ctx context.Context, deps resource.Dependencies, conf resource.C
 		return nil, err
 	}
 
+	//Default value for persistence
+	if t.minTrackPersistence == 0 {
+		t.minTrackPersistence = DefaultMinTrackPersistence
+	}
 	// Default value for frequency = 10Hz
 	if t.frequency == 0 {
 		t.frequency = DefaultMaxFrequency
@@ -120,7 +127,7 @@ func newTracker(ctx context.Context, deps resource.Dependencies, conf resource.C
 	t.cancelContext = cancelableCtx
 
 	// Do the first pass to populate the first set of 2 detections.
-	starterDets := make([][]objdet.Detection, 2)
+	starterDets := make([][]*track, 2)
 	stream, err := t.cam.Stream(t.cancelContext, nil)
 	if err != nil {
 		return nil, err
@@ -134,12 +141,14 @@ func newTracker(ctx context.Context, deps resource.Dependencies, conf resource.C
 		if err != nil {
 			return nil, err
 		}
-		starterDets[i] = detections
+		filteredDets := FilterDetections(t.chosenLabels, detections, t.minConfidence)
+		tracks := newTracks(filteredDets, t.minTrackPersistence)
+		starterDets[i] = tracks
 	}
-	filteredOld := FilterDetections(t.chosenLabels, starterDets[0], t.minConfidence)
-	filteredNew := FilterDetections(t.chosenLabels, starterDets[1], t.minConfidence)
+	filteredOld := starterDets[0]
+	filteredNew := starterDets[1]
 	// Rename (from scratch)
-	renamedOld := make([]objdet.Detection, 0, len(filteredOld))
+	renamedOld := make([]*track, 0, len(filteredOld))
 	for _, det := range filteredOld {
 		newDet := t.RenameFirstTime(det)
 		renamedOld = append(renamedOld, newDet)
@@ -151,19 +160,23 @@ func newTracker(ctx context.Context, deps resource.Dependencies, conf resource.C
 		return nil, err
 	}
 	matches := HA.Execute()
-	var lostDetections []objdet.Detection
+	var lostDetections []*track
 	for idx, _ := range matches {
 		if matches[idx] == -1 {
-			lostDetections = append(lostDetections, renamedOld[idx])
+			// if lost detection is not stable, discard it
+			if renamedOld[idx].isStable() {
+				lostDetections = append(lostDetections, renamedOld[idx])
+			}
 		}
 	}
 	t.lostDetectionsBuffer.AppendDets(lostDetections)
 
 	// Rename from temporal matches. New det copies old det's label
-	renamedNew, _ := t.RenameFromMatches(matches, matchMtx, renamedOld, filteredNew)
-	if len(renamedNew) > 0 {
+	renamedNew, newlyStable, _ := t.RenameFromMatches(matches, matchMtx, renamedOld, filteredNew)
+	if len(newlyStable) > 0 {
 		t.trigger()
 	}
+	renamedNew = append(renamedNew, newlyStable...)
 	t.lastDetections = renamedNew
 	t.currDetections.mutex.Lock()
 	t.currDetections.detections = renamedNew
@@ -205,37 +218,45 @@ func (t *myTracker) run(stream gostream.VideoStream, cancelableCtx context.Conte
 				t.logger.Errorf("can't get detections. got err: %s", err)
 				continue
 			}
-			filteredNew := FilterDetections(t.chosenLabels, detections, t.minConfidence)
+			filteredDets := FilterDetections(t.chosenLabels, detections, t.minConfidence)
+			// all new tracks get a fresh persistence counter
+			filteredNew := newTracks(filteredDets, t.minTrackPersistence)
 
 			// Store oldDetection and lost detections in allDetections
 			allDetections := t.lastDetections
 			for _, dets := range t.lostDetectionsBuffer.detections {
-				for _, det := range dets {
-					allDetections = append(allDetections, det)
-				}
+				allDetections = append(allDetections, dets...)
 			}
 			// Build and solve cost matrix via Munkres' method
 			matchMtx := t.BuildMatchingMatrix(allDetections, filteredNew)
 			HA, _ := hg.NewHungarianAlgorithm(matchMtx)
 			matches := HA.Execute()
-			// Store the lost detections in the buffer
-			var lostDetections []objdet.Detection
+			// Store the lost detections in the buffer, drop lost detections
+			// if they were not considered stable
+			var lostDetections []*track
 			for idx, _ := range t.lastDetections {
 				if matches[idx] == -1 {
-					lostDetections = append(lostDetections, t.lastDetections[idx])
+					if t.lastDetections[idx].isStable() {
+						lostDetections = append(lostDetections, t.lastDetections[idx])
+					} else {
+						// drop lost detections from track list as well
+						countLabel := getTrackingLabel(t.lastDetections[idx])
+						delete(t.tracks, countLabel)
+					}
 				}
 			}
 			t.lostDetectionsBuffer.AppendDets(lostDetections)
-			// Rename from temporal matches. New det copies old det's label
-			renamedNew, freshDets := t.RenameFromMatches(matches, matchMtx, allDetections, filteredNew)
-			if len(freshDets) > 0 {
+			// Returns a new set of detections, from matching allDetections with the filteredNew
+			// All three outputs must be summed together to get the full set of new detections
+			renamedNew, newlyStable, freshDets := t.RenameFromMatches(matches, matchMtx, allDetections, filteredNew)
+			if len(newlyStable) > 0 {
 				//trigger classification and schedule "untrigger"
 				t.trigger()
 
 				// add the detections to the logs
 				t.allFreshObjects.mutex.Lock()
-				for _, det := range freshDets {
-					to, err := newTrackedObjectFromLabel(det.Label())
+				for _, det := range newlyStable {
+					to, err := newTrackedObjectFromLabel(det.Det.Label())
 					if err != nil {
 						t.logger.Error(err)
 					}
@@ -243,6 +264,8 @@ func (t *myTracker) run(stream gostream.VideoStream, cancelableCtx context.Conte
 				}
 				t.allFreshObjects.mutex.Unlock()
 			}
+			renamedNew = append(renamedNew, newlyStable...)
+			renamedNew = append(renamedNew, freshDets...)
 			t.lastDetections = renamedNew
 			t.currDetections.mutex.Lock()
 			t.currDetections.detections = renamedNew
@@ -292,18 +315,22 @@ func (t *myTracker) trigger() {
 
 // Config contains names for necessary resources (camera and vision service)
 type Config struct {
-	CameraName      string             `json:"camera_name"`
-	DetectorName    string             `json:"detector_name"`
-	ChosenLabels    map[string]float64 `json:"chosen_labels"`
-	MaxFrequency    float64            `json:"max_frequency_hz"`
-	MinConfidence   *float64           `json:"min_confidence,omitempty"`
-	TriggerCoolDown *float64           `json:"trigger_cool_down_s,omitempty"`
-	BufferSize      int                `json:"buffer_size,omitempty"`
+	CameraName          string             `json:"camera_name"`
+	DetectorName        string             `json:"detector_name"`
+	ChosenLabels        map[string]float64 `json:"chosen_labels"`
+	MaxFrequency        float64            `json:"max_frequency_hz"`
+	MinConfidence       *float64           `json:"min_confidence,omitempty"`
+	TriggerCoolDown     *float64           `json:"trigger_cool_down_s,omitempty"`
+	BufferSize          int                `json:"buffer_size,omitempty"`
+	MinTrackPersistence int                `json:"min_track_persistence"`
 }
 
 // Validate validates the config and returns implicit dependencies,
 // this Validate checks if the camera and detector(vision svc) exist for the module's vision model.
 func (cfg *Config) Validate(path string) ([]string, error) {
+	if cfg.MinTrackPersistence < 0 {
+		return nil, errors.New("attribute min_track_persistence cannot be less than 0")
+	}
 	// this makes them required for the model to successfully build
 	if cfg.CameraName == "" {
 		return nil, fmt.Errorf(`expected "camera_name" attribute for object tracker %q`, path)
@@ -336,14 +363,16 @@ func (t *myTracker) Reconfigure(ctx context.Context, deps resource.Dependencies,
 	}
 	t.frequency = trackerConfig.MaxFrequency
 
+	t.minTrackPersistence = trackerConfig.MinTrackPersistence
+
 	//config buffer size
 	if trackerConfig.BufferSize > 0 {
 		if trackerConfig.BufferSize > 256 {
 			return errors.New("buffer size must be between 1 and 256")
 		}
-		t.lostDetectionsBuffer = newDetectionsBuffer(trackerConfig.BufferSize)
+		t.lostDetectionsBuffer = newTracksBuffer(trackerConfig.BufferSize)
 	} else {
-		t.lostDetectionsBuffer = newDetectionsBuffer(DefaultBufferSize)
+		t.lostDetectionsBuffer = newTracksBuffer(DefaultBufferSize)
 	}
 
 	//config trigger cool down
@@ -394,7 +423,7 @@ func (t *myTracker) DetectionsFromCamera(
 		return nil, ctx.Err()
 	default:
 		t.currDetections.mutex.RLock()
-		dets := t.currDetections.detections
+		dets := getStableDetections(t.currDetections.detections)
 		t.currDetections.mutex.RUnlock()
 		return dets, nil
 	}
@@ -408,7 +437,7 @@ func (t *myTracker) Detections(ctx context.Context, img image.Image, extra map[s
 		return nil, ctx.Err()
 	default:
 		t.currDetections.mutex.RLock()
-		dets := t.currDetections.detections
+		dets := getStableDetections(t.currDetections.detections)
 		t.currDetections.mutex.RUnlock()
 		return dets, nil
 	}
@@ -474,7 +503,7 @@ func (t *myTracker) CaptureAllFromCamera(
 		}
 		if opt.ReturnDetections {
 			t.currDetections.mutex.RLock()
-			detections = t.currDetections.detections
+			detections = getStableDetections(t.currDetections.detections)
 			t.currDetections.mutex.RUnlock()
 		}
 		if opt.ReturnClassifications {
@@ -494,32 +523,11 @@ func (t *myTracker) Close(ctx context.Context) error {
 	return nil
 }
 
-type trackedObject struct {
-	FullLabel string
-	Label     string
-	Id        int
-	Time      string
-}
 type benchmark struct {
 	Slowest      float64
 	Fastest      float64
 	Average      float64
 	NumberOfRuns int
-}
-
-func newTrackedObjectFromLabel(label string) (trackedObject, error) {
-	parts := strings.Split(label, "_")
-	id, err := strconv.Atoi(parts[1])
-	if err != nil {
-		return trackedObject{}, errors.Wrapf(err, "unable to parse label %v", label)
-	}
-	return trackedObject{
-		FullLabel: label,
-		Label:     parts[0],
-		Id:        id,
-		Time:      strings.Join(parts[2:], "_"),
-	}, nil
-
 }
 
 // DoCommand will return the slowest, fastest, and average time of the tracking module
@@ -555,30 +563,30 @@ func (t *myTracker) DoCommand(ctx context.Context, cmd map[string]interface{}) (
 	return out, nil
 }
 
-type detectionsBuffer struct {
-	detections [][]objdet.Detection
+type tracksBuffer struct {
+	detections [][]*track
 	size       int
 }
 
-// newDetectionsBuffer initializes a new fixed-length queue with the specified size.
-func newDetectionsBuffer(size int) *detectionsBuffer {
-	return &detectionsBuffer{
-		detections: make([][]objdet.Detection, 0, size),
+// newTracksBuffer initializes a new fixed-length queue with the specified size.
+func newTracksBuffer(size int) *tracksBuffer {
+	return &tracksBuffer{
+		detections: make([][]*track, 0, size),
 		size:       size,
 	}
 }
-func (b *detectionsBuffer) AppendDets(newDets []objdet.Detection) {
+func (b *tracksBuffer) AppendDets(newDets []*track) {
 	if len(b.detections) == b.size {
 		b.detections = b.detections[1:]
 	}
 
 	//remove old dets to match new dets only on the most recent detections
 	for _, newDet := range newDets {
-		countLabel := strings.Join(strings.Split(newDet.Label(), "_")[0:2], "_")
+		countLabel := strings.Join(strings.Split(newDet.Det.Label(), "_")[0:2], "_")
 		for i := range b.detections {
 			dets := b.detections[i]
 			for idx, det := range dets {
-				oldCountLabel := strings.Join(strings.Split(det.Label(), "_")[0:2], "_")
+				oldCountLabel := strings.Join(strings.Split(det.Det.Label(), "_")[0:2], "_")
 				if countLabel == oldCountLabel {
 					b.detections[i] = append(dets[:idx], dets[idx+1:]...)
 					break

--- a/object_tracker/object_tracker_test.go
+++ b/object_tracker/object_tracker_test.go
@@ -1,17 +1,19 @@
 package object_tracker
 
 import (
+	"image"
+	"testing"
+
 	hg "github.com/charles-haynes/munkres"
 	"go.viam.com/rdk/services/vision"
 	objdet "go.viam.com/rdk/vision/objectdetection"
 	"go.viam.com/test"
-	"image"
-	"testing"
 )
 
 const (
-	LabelDet0 string = "cat"
-	LabelDet1 string = "fish"
+	LabelDet0            string = "cat"
+	LabelDet1            string = "fish"
+	TestPersistenceLimit int    = 2
 )
 
 type FakeDetector struct {
@@ -24,8 +26,8 @@ func (fd *FakeDetector) fakeDetections() []objdet.Detection {
 	return fd.res[fd.it-1]
 }
 
-func checkLabel(t *testing.T, value objdet.Detection, target string) {
-	test.That(t, value.Label()[:len(target)], test.ShouldEqual, target)
+func checkLabel(t *testing.T, value *track, target string) {
+	test.That(t, value.Det.Label()[:len(target)], test.ShouldEqual, target)
 }
 
 func TestTracker(t *testing.T) {
@@ -43,7 +45,7 @@ func TestTracker(t *testing.T) {
 
 	fakeTracker := &myTracker{
 		classCounter: make(map[string]int),
-		tracks:       make(map[string][]objdet.Detection),
+		tracks:       make(map[string][]*track),
 		properties: vision.Properties{
 			ClassificationSupported: true,
 			DetectionSupported:      true,
@@ -52,13 +54,13 @@ func TestTracker(t *testing.T) {
 		allFreshObjects: allObjects{
 			objects: []trackedObject{},
 		},
-		lostDetectionsBuffer: newDetectionsBuffer(10),
+		lostDetectionsBuffer: newTracksBuffer(10),
 	}
 
 	//initialisation
-	filteredOld := fd.fakeDetections() // get cat and fish
-	filteredNew := fd.fakeDetections() //get cat
-	renamedOld := make([]objdet.Detection, 0, len(filteredOld))
+	filteredOld := newTracks(fd.fakeDetections(), TestPersistenceLimit) // get cat and fish
+	filteredNew := newTracks(fd.fakeDetections(), TestPersistenceLimit) //get cat
+	renamedOld := make([]*track, 0, len(filteredOld))
 	for _, det := range filteredOld {
 		newDet := fakeTracker.RenameFirstTime(det) //create label fish_0 and cat_0
 		renamedOld = append(renamedOld, newDet)
@@ -69,7 +71,7 @@ func TestTracker(t *testing.T) {
 	HA, err := hg.NewHungarianAlgorithm(matchMtx)
 	test.That(t, err, test.ShouldBeNil)
 	matches := HA.Execute()
-	lostDetections := []objdet.Detection{}
+	lostDetections := []*track{}
 	for idx, _ := range matches {
 		if matches[idx] == -1 {
 			lostDetections = append(lostDetections, renamedOld[idx])
@@ -80,9 +82,10 @@ func TestTracker(t *testing.T) {
 	fakeTracker.lostDetectionsBuffer.AppendDets(lostDetections)
 
 	// Rename from temporal matches. New det copies old det's label
-	renamedNew, _ := fakeTracker.RenameFromMatches(matches, matchMtx, renamedOld, filteredNew)
+	renamedNew, newlyStable, _ := fakeTracker.RenameFromMatches(matches, matchMtx, renamedOld, filteredNew)
 
 	//Store stuffs
+	renamedNew = append(renamedNew, newlyStable...)
 	fakeTracker.lastDetections = renamedNew
 	fakeTracker.currDetections.mutex.Lock()
 	fakeTracker.currDetections.detections = renamedNew
@@ -97,7 +100,7 @@ func TestTracker(t *testing.T) {
 
 	//End of initialisation get new detections
 
-	filteredNew = fd.fakeDetections() //get fish but somewhere else
+	filteredNew = newTracks(fd.fakeDetections(), TestPersistenceLimit) //get fish but somewhere else
 
 	// Store oldDetection and lost detections in allDetections
 	allDetections := fakeTracker.lastDetections
@@ -111,7 +114,7 @@ func TestTracker(t *testing.T) {
 	matchMtx = fakeTracker.BuildMatchingMatrix(allDetections, filteredNew)
 	HA, _ = hg.NewHungarianAlgorithm(matchMtx)
 	matches = HA.Execute()
-	lostDetections = []objdet.Detection{}
+	lostDetections = []*track{}
 	for idx, _ := range fakeTracker.lastDetections {
 		if matches[idx] == -1 {
 			lostDetections = append(lostDetections, fakeTracker.lastDetections[idx])
@@ -122,10 +125,11 @@ func TestTracker(t *testing.T) {
 
 	//}
 	// Rename from temporal matches. New det copies old det's label
-	renamedNew, _ = fakeTracker.RenameFromMatches(matches, matchMtx, allDetections, filteredNew)
+	renamedNew, newlyStable, _ = fakeTracker.RenameFromMatches(matches, matchMtx, allDetections, filteredNew)
 	fakeTracker.lostDetectionsBuffer.AppendDets(lostDetections)
 
 	// Store results
+	renamedNew = append(renamedNew, newlyStable...)
 	fakeTracker.lastDetections = renamedNew
 	fakeTracker.currDetections.mutex.Lock()
 	fakeTracker.currDetections.detections = renamedNew
@@ -136,11 +140,11 @@ func TestTracker(t *testing.T) {
 	currDetections = fakeTracker.currDetections.detections
 	fakeTracker.currDetections.mutex.RUnlock()
 	test.That(t, len(currDetections), test.ShouldEqual, 1)
-	test.That(t, currDetections[0].Label()[:len(LabelDet1)], test.ShouldEqual, LabelDet1)
+	test.That(t, currDetections[0].Det.Label()[:len(LabelDet1)], test.ShouldEqual, LabelDet1)
 
 	//Detecting a new cat, now we want to make sure that we don't have 2 "fish_zero"
 	//when fish get lost
-	filteredNew = fd.fakeDetections() //get cat again
+	filteredNew = newTracks(fd.fakeDetections(), TestPersistenceLimit) //get cat again
 	test.That(t, len(filteredNew), test.ShouldEqual, 1)
 	checkLabel(t, filteredNew[0], LabelDet0)
 
@@ -156,7 +160,7 @@ func TestTracker(t *testing.T) {
 	matchMtx = fakeTracker.BuildMatchingMatrix(allDetections, filteredNew)
 	HA, _ = hg.NewHungarianAlgorithm(matchMtx)
 	matches = HA.Execute()
-	lostDetections = []objdet.Detection{}
+	lostDetections = []*track{}
 	for idx, _ := range fakeTracker.lastDetections {
 		if matches[idx] == -1 {
 			lostDetections = append(lostDetections, fakeTracker.lastDetections[idx])
@@ -167,18 +171,19 @@ func TestTracker(t *testing.T) {
 
 	//}
 	// Rename from temporal matches. New det copies old det's label
-	renamedNew, _ = fakeTracker.RenameFromMatches(matches, matchMtx, allDetections, filteredNew)
+	renamedNew, newlyStable, _ = fakeTracker.RenameFromMatches(matches, matchMtx, allDetections, filteredNew)
+	renamedNew = append(renamedNew, newlyStable...)
 	test.That(t, len(fakeTracker.lostDetectionsBuffer.detections[0]), test.ShouldEqual, 1)
 	checkLabel(t, fakeTracker.lostDetectionsBuffer.detections[0][0], LabelDet1) //check if there used to be fish
 	test.That(
 		t,
-		fakeTracker.lostDetectionsBuffer.detections[0][0].BoundingBox().Min,
+		fakeTracker.lostDetectionsBuffer.detections[0][0].Det.BoundingBox().Min,
 		test.ShouldResemble,
 		image.Pt(20, 20),
 	)
 	test.That(
 		t,
-		fakeTracker.lostDetectionsBuffer.detections[0][0].BoundingBox().Max,
+		fakeTracker.lostDetectionsBuffer.detections[0][0].Det.BoundingBox().Max,
 		test.ShouldResemble,
 		image.Pt(30, 30),
 	)
@@ -191,27 +196,27 @@ func TestTracker(t *testing.T) {
 	checkLabel(t, fakeTracker.lostDetectionsBuffer.detections[2][0], LabelDet1)
 	test.That(
 		t,
-		fakeTracker.lostDetectionsBuffer.detections[2][0].BoundingBox().Min,
+		fakeTracker.lostDetectionsBuffer.detections[2][0].Det.BoundingBox().Min,
 		test.ShouldResemble,
 		image.Pt(22, 22),
 	)
 	test.That(
 		t,
-		fakeTracker.lostDetectionsBuffer.detections[2][0].BoundingBox().Max,
+		fakeTracker.lostDetectionsBuffer.detections[2][0].Det.BoundingBox().Max,
 		test.ShouldResemble,
 		image.Pt(33, 33),
 	)
 
 	test.That(
 		t,
-		fakeTracker.lostDetectionsBuffer.detections[2][0].BoundingBox().Max,
+		fakeTracker.lostDetectionsBuffer.detections[2][0].Det.BoundingBox().Max,
 		test.ShouldNotResemble,
 		image.Pt(20, 20),
 	)
 
 	test.That(
 		t,
-		fakeTracker.lostDetectionsBuffer.detections[2][0].BoundingBox().Max,
+		fakeTracker.lostDetectionsBuffer.detections[2][0].Det.BoundingBox().Max,
 		test.ShouldNotResemble,
 		image.Pt(30, 30),
 	)

--- a/object_tracker/sort.go
+++ b/object_tracker/sort.go
@@ -2,7 +2,6 @@
 package object_tracker
 
 import (
-	objdet "go.viam.com/rdk/vision/objectdetection"
 	"image"
 	"strings"
 )
@@ -34,23 +33,26 @@ func PredictNextFrame(old, curr image.Rectangle) image.Rectangle {
 // BuildMatchingMatrix sets up a cost matrix for the Hungarian algorithm.
 // We compare the predicted location (if enough track info available) to detected location
 // In this implementation, cost is -IOU between bboxes (b/c solver will find min)
-func (t *myTracker) BuildMatchingMatrix(oldDetections, newDetections []objdet.Detection) [][]float64 {
+func (t *myTracker) BuildMatchingMatrix(oldDetections, newDetections []*track) [][]float64 {
 	h, w := len(oldDetections), len(newDetections)
 	matchMtx := make([][]float64, h)
 
 	for i, oldD := range oldDetections {
 		row := make([]float64, w)
 		// Find track. If long enough, make prediction and use that. Otherwise use self
-		label := strings.Join(strings.Split(oldD.Label(), "_")[0:2], "_")
+		label := strings.Join(strings.Split(oldD.Det.Label(), "_")[0:2], "_")
 		track := t.tracks[label]
 		if len(track) >= 2 {
-			pred := PredictNextFrame(*track[len(track)-2].BoundingBox(), *track[len(track)-1].BoundingBox())
+			pred := PredictNextFrame(
+				*track[len(track)-2].Det.BoundingBox(),
+				*track[len(track)-1].Det.BoundingBox(),
+			)
 			for j, newD := range newDetections {
-				row[j] = -IOU(&pred, newD.BoundingBox())
+				row[j] = -IOU(&pred, newD.Det.BoundingBox())
 			}
 		} else {
 			for j, newD := range newDetections {
-				row[j] = -IOU(oldD.BoundingBox(), newD.BoundingBox())
+				row[j] = -IOU(oldD.Det.BoundingBox(), newD.Det.BoundingBox())
 			}
 		}
 		matchMtx[i] = row

--- a/object_tracker/track.go
+++ b/object_tracker/track.go
@@ -1,0 +1,92 @@
+package object_tracker
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+	objdet "go.viam.com/rdk/vision/objectdetection"
+)
+
+// A track stores information about the bounding box as well as its persistence properties
+// across frames
+type track struct {
+	Det              objdet.Detection
+	persistenceLimit int
+	persistenceCount int
+	stable           bool
+}
+
+// newTrack turns a bounding box into a new track with a fresh persistence counter
+func newTrack(det objdet.Detection, lim int) *track {
+	return &track{det, lim, 0, false}
+}
+
+// newTracks turns a slice of bounding boxes into a track with a fresh persistence counter
+func newTracks(dets []objdet.Detection, lim int) []*track {
+	tracks := make([]*track, 0, len(dets))
+	for _, d := range dets {
+		tracks = append(tracks, newTrack(d, lim))
+	}
+	return tracks
+}
+
+// clone will duplicate all the properties of the track
+func (tr *track) clone() *track {
+	return &track{
+		tr.Det,
+		tr.persistenceLimit,
+		tr.persistenceCount,
+		tr.stable,
+	}
+}
+
+// isStable returns that the track has persisted long enough to count as stable
+func (tr *track) isStable() bool {
+	return tr.stable
+}
+
+// addPersistence add to the persistence counter
+func (tr *track) addPersistence() {
+	if tr.stable {
+		return
+	}
+	tr.persistenceCount += 1
+	if tr.persistenceCount >= tr.persistenceLimit {
+		tr.stable = true
+	}
+}
+
+// return only the bounding boxes associated with stable tracks
+func getStableDetections(tracks []*track) []objdet.Detection {
+	dets := make([]objdet.Detection, 0, len(tracks))
+	for _, tr := range tracks {
+		if tr.stable {
+			dets = append(dets, tr.Det)
+		}
+	}
+	return dets
+}
+
+// trackedObject is the log info associated with the track that is stable
+type trackedObject struct {
+	FullLabel string
+	Label     string
+	Id        int
+	Time      string
+}
+
+func newTrackedObjectFromLabel(label string) (trackedObject, error) {
+	parts := strings.Split(label, "_")
+	id, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return trackedObject{}, errors.Wrapf(err, "unable to parse label %v", label)
+	}
+	return trackedObject{
+		FullLabel: label,
+		Label:     parts[0],
+		Id:        id,
+		Time:      strings.Join(parts[2:], "_"),
+	}, nil
+
+}


### PR DESCRIPTION
The same code as in pizza-tracking, but in object-tracking


 - Creates a struct called track that replaces the raw bounding box, in order to add information about persistence
 - Drops un-matched tracks that get lost before the persistence period is complete
 - only emits a new object classifications when something becomes newly stable
 - new optional parameter called min_track_persistence
