### PR TITLE
[RSDK-10176] - Add default camera behavior to object-tracker

### DIFF
--- a/object_tracker/object_tracker.go
+++ b/object_tracker/object_tracker.go
@@ -187,7 +187,7 @@ func newTracker(ctx context.Context, deps resource.Dependencies, conf resource.C
 		t.run(stream, t.cancelContext)
 	}, func() {
 		t.cancelFunc()
-		stream.Close(t.cancelContext)
+		viamutils.UncheckedError(stream.Close(t.cancelContext))
 		t.activeBackgroundWorkers.Done()
 	})
 

--- a/object_tracker/object_tracker.go
+++ b/object_tracker/object_tracker.go
@@ -413,7 +413,7 @@ func (t *myTracker) DetectionsFromCamera(
 	cameraName string,
 	extra map[string]interface{},
 ) ([]objdet.Detection, error) {
-	if cameraName != t.camName {
+	if cameraName == "" || cameraName != t.camName {
 		return nil, errors.Errorf("Camera name given to method, %v is not the same as configured camera %v", cameraName, t.camName)
 	}
 	select {
@@ -449,7 +449,7 @@ func (t *myTracker) ClassificationsFromCamera(
 	n int,
 	extra map[string]interface{},
 ) (classification.Classifications, error) {
-	if cameraName != t.camName {
+	if cameraName == "" || cameraName != t.camName {
 		return nil, errors.Errorf("Camera name given to method, %v is not the same as configured camera %v", cameraName, t.camName)
 	}
 	if newInstance := t.newInstance.Load(); newInstance {
@@ -496,7 +496,7 @@ func (t *myTracker) CaptureAllFromCamera(
 		return viscapture.VisCapture{}, ctx.Err()
 	default:
 		if opt.ReturnImage {
-			if cameraName != t.camName {
+			if cameraName == "" || cameraName != t.camName {
 				return viscapture.VisCapture{}, errors.Errorf("Camera name given to method, %v is not the same as configured camera %v", cameraName, t.camName)
 			}
 			img = *t.currImg.Load()

--- a/object_tracker/object_tracker.go
+++ b/object_tracker/object_tracker.go
@@ -413,7 +413,7 @@ func (t *myTracker) DetectionsFromCamera(
 	cameraName string,
 	extra map[string]interface{},
 ) ([]objdet.Detection, error) {
-	if cameraName == "" || cameraName != t.camName {
+	if cameraName != "" && cameraName != t.camName {
 		return nil, errors.Errorf("Camera name given to method, %v is not the same as configured camera %v", cameraName, t.camName)
 	}
 	select {
@@ -449,7 +449,7 @@ func (t *myTracker) ClassificationsFromCamera(
 	n int,
 	extra map[string]interface{},
 ) (classification.Classifications, error) {
-	if cameraName == "" || cameraName != t.camName {
+	if cameraName != "" && cameraName != t.camName {
 		return nil, errors.Errorf("Camera name given to method, %v is not the same as configured camera %v", cameraName, t.camName)
 	}
 	if newInstance := t.newInstance.Load(); newInstance {
@@ -496,7 +496,7 @@ func (t *myTracker) CaptureAllFromCamera(
 		return viscapture.VisCapture{}, ctx.Err()
 	default:
 		if opt.ReturnImage {
-			if cameraName == "" || cameraName != t.camName {
+			if cameraName != "" && cameraName != t.camName {
 				return viscapture.VisCapture{}, errors.Errorf("Camera name given to method, %v is not the same as configured camera %v", cameraName, t.camName)
 			}
 			img = *t.currImg.Load()

--- a/object_tracker/object_tracker.go
+++ b/object_tracker/object_tracker.go
@@ -187,7 +187,7 @@ func newTracker(ctx context.Context, deps resource.Dependencies, conf resource.C
 		t.run(stream, t.cancelContext)
 	}, func() {
 		t.cancelFunc()
-		viamutils.UncheckedError(stream.Close(t.cancelContext))
+		stream.Close(t.cancelContext)
 		t.activeBackgroundWorkers.Done()
 	})
 

--- a/object_tracker/object_tracker_test.go
+++ b/object_tracker/object_tracker_test.go
@@ -344,10 +344,15 @@ func TestTracker(t *testing.T) {
 
 func TestInvalidCameraNamesError(t *testing.T) {
 	ctx := context.Background()
+	var img image.Image
+	rect := image.Rect(0, 0, 10, 10)
+	img = rimage.NewImageFromBounds(rect)
+
 	fakeTracker := &myTracker{
-		camName: "test",
+		camName:       "test",
 		cancelContext: ctx,
 	}
+	fakeTracker.currImg.Store(&img)
 
 	invalidName := "not-camera"
 	invalidNameErrorMessage := "Camera name given to method, not-camera is not the same as configured camera test"
@@ -375,4 +380,8 @@ func TestInvalidCameraNamesError(t *testing.T) {
 	_, err = fakeTracker.CaptureAllFromCamera(ctx, invalidName, viscapture.CaptureOptions{ReturnImage: true}, emptyMap)
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, invalidNameErrorMessage)
+
+	// Test empty (valid) camera name in CaptureAllFromCamera
+	_, err = fakeTracker.CaptureAllFromCamera(ctx, "", viscapture.CaptureOptions{ReturnImage: true}, emptyMap)
+	test.That(t, err, test.ShouldBeNil)
 }

--- a/object_tracker/object_tracker_test.go
+++ b/object_tracker/object_tracker_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"image"
-	"sync/atomic"
 	"testing"
 
 	"go.viam.com/rdk/components/camera"
@@ -347,7 +346,6 @@ func TestInvalidCameraNamesError(t *testing.T) {
 	ctx := context.Background()
 	fakeTracker := &myTracker{
 		camName: "test",
-		currImg: atomic.Pointer[image.Image]{},
 		cancelContext: ctx,
 	}
 
@@ -361,7 +359,7 @@ func TestInvalidCameraNamesError(t *testing.T) {
 
 	// Test empty (valid) camera name in DetectionsFromCamera
 	_, err = fakeTracker.DetectionsFromCamera(ctx, "", make(map[string]interface{}))
-	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err, test.ShouldBeNil)
 
 	// Test invalid camera name in ClassificationsFromCamera
 	_, err = fakeTracker.ClassificationsFromCamera(ctx, invalidName, 0, make(map[string]interface{}))
@@ -370,14 +368,10 @@ func TestInvalidCameraNamesError(t *testing.T) {
 
 	// Test empty (valid) camera name in ClassificationsFromCamera
 	_, err = fakeTracker.ClassificationsFromCamera(ctx, "", 0, make(map[string]interface{}))
-	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err, test.ShouldBeNil)
 
 	// Test invalid camera name in CaptureAllFromCamera
 	_, err = fakeTracker.CaptureAllFromCamera(ctx, invalidName, viscapture.CaptureOptions{ReturnImage: true}, make(map[string]interface{}))
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, invalidNameErrorMessage)
-
-	// Test empty (valid) camera name in CaptureAllFromCamera
-	_, err = fakeTracker.CaptureAllFromCamera(ctx, "", viscapture.CaptureOptions{ReturnImage: true}, make(map[string]interface{}))
-	test.That(t, err, test.ShouldNotBeNil)
 }

--- a/object_tracker/object_tracker_test.go
+++ b/object_tracker/object_tracker_test.go
@@ -351,27 +351,28 @@ func TestInvalidCameraNamesError(t *testing.T) {
 
 	invalidName := "not-camera"
 	invalidNameErrorMessage := "Camera name given to method, not-camera is not the same as configured camera test"
+	emptyMap := make(map[string]interface{})
 
 	// Test invalid camera name in DetectionsFromCamera
-	_, err := fakeTracker.DetectionsFromCamera(ctx, invalidName, make(map[string]interface{}))
+	_, err := fakeTracker.DetectionsFromCamera(ctx, invalidName, emptyMap)
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, invalidNameErrorMessage)
 
 	// Test empty (valid) camera name in DetectionsFromCamera
-	_, err = fakeTracker.DetectionsFromCamera(ctx, "", make(map[string]interface{}))
+	_, err = fakeTracker.DetectionsFromCamera(ctx, "", emptyMap)
 	test.That(t, err, test.ShouldBeNil)
 
 	// Test invalid camera name in ClassificationsFromCamera
-	_, err = fakeTracker.ClassificationsFromCamera(ctx, invalidName, 0, make(map[string]interface{}))
+	_, err = fakeTracker.ClassificationsFromCamera(ctx, invalidName, 0, emptyMap)
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, invalidNameErrorMessage)
 
 	// Test empty (valid) camera name in ClassificationsFromCamera
-	_, err = fakeTracker.ClassificationsFromCamera(ctx, "", 0, make(map[string]interface{}))
+	_, err = fakeTracker.ClassificationsFromCamera(ctx, "", 0, emptyMap)
 	test.That(t, err, test.ShouldBeNil)
 
 	// Test invalid camera name in CaptureAllFromCamera
-	_, err = fakeTracker.CaptureAllFromCamera(ctx, invalidName, viscapture.CaptureOptions{ReturnImage: true}, make(map[string]interface{}))
+	_, err = fakeTracker.CaptureAllFromCamera(ctx, invalidName, viscapture.CaptureOptions{ReturnImage: true}, emptyMap)
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, invalidNameErrorMessage)
 }

--- a/object_tracker/object_tracker_test.go
+++ b/object_tracker/object_tracker_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"image"
+	"sync/atomic"
 	"testing"
 
 	"go.viam.com/rdk/components/camera"
@@ -12,6 +13,7 @@ import (
 	"go.viam.com/rdk/rimage"
 	"go.viam.com/rdk/testutils/inject"
 	"go.viam.com/rdk/utils"
+	"go.viam.com/rdk/vision/viscapture"
 
 	hg "github.com/charles-haynes/munkres"
 	"go.viam.com/rdk/services/vision"
@@ -339,4 +341,43 @@ func TestTracker(t *testing.T) {
 	fakeTracker.currDetections.mutex.RUnlock()
 	test.That(t, len(currDetections), test.ShouldEqual, 1)
 	checkLabel(t, currDetections[0], LabelDet0)
+}
+
+func TestInvalidCameraNamesError(t *testing.T) {
+	ctx := context.Background()
+	fakeTracker := &myTracker{
+		camName: "test",
+		currImg: atomic.Pointer[image.Image]{},
+		cancelContext: ctx,
+	}
+
+	invalidName := "not-camera"
+	invalidNameErrorMessage := "Camera name given to method, not-camera is not the same as configured camera test"
+
+	// Test invalid camera name in DetectionsFromCamera
+	_, err := fakeTracker.DetectionsFromCamera(ctx, invalidName, make(map[string]interface{}))
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, invalidNameErrorMessage)
+
+	// Test empty (valid) camera name in DetectionsFromCamera
+	_, err = fakeTracker.DetectionsFromCamera(ctx, "", make(map[string]interface{}))
+	test.That(t, err, test.ShouldNotBeNil)
+
+	// Test invalid camera name in ClassificationsFromCamera
+	_, err = fakeTracker.ClassificationsFromCamera(ctx, invalidName, 0, make(map[string]interface{}))
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, invalidNameErrorMessage)
+
+	// Test empty (valid) camera name in ClassificationsFromCamera
+	_, err = fakeTracker.ClassificationsFromCamera(ctx, "", 0, make(map[string]interface{}))
+	test.That(t, err, test.ShouldNotBeNil)
+
+	// Test invalid camera name in CaptureAllFromCamera
+	_, err = fakeTracker.CaptureAllFromCamera(ctx, invalidName, viscapture.CaptureOptions{ReturnImage: true}, make(map[string]interface{}))
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, invalidNameErrorMessage)
+
+	// Test empty (valid) camera name in CaptureAllFromCamera
+	_, err = fakeTracker.CaptureAllFromCamera(ctx, "", viscapture.CaptureOptions{ReturnImage: true}, make(map[string]interface{}))
+	test.That(t, err, test.ShouldNotBeNil)
 }


### PR DESCRIPTION
## Changes
- [x] allow `CameraName` to be an empty string in all `*FromCamera` methods
- [x] add tests to validate this behavior
